### PR TITLE
Don't accidently create relative links

### DIFF
--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -534,7 +534,7 @@ def append_slash_redirect(environ, code=301):
                     the redirect.
     :param code: the status code for the redirect.
     """
-    new_path = environ["PATH_INFO"].strip("/") + "/"
+    new_path = environ["PATH_INFO"].rstrip("/") + "/"
     query_string = environ.get("QUERY_STRING")
     if query_string:
         new_path += "?" + query_string


### PR DESCRIPTION
append_slash_redirect should not change absolute links to relative ones.
That breaks serving applications via nginx.

e.g.
PATH_INFO="/help/test"  -> the Location would be "help/test/" and this is translated correctly by nginx to:
https://example.com/help/help/test